### PR TITLE
Add ability to edit messages

### DIFF
--- a/controllers/page_types/Forum.php
+++ b/controllers/page_types/Forum.php
@@ -4,6 +4,7 @@ namespace Concrete\Package\OrticForum\Controller\PageType;
 
 use Concrete\Core\Page\Controller\PageTypeController;
 use Core;
+use User;
 
 class Forum extends PageTypeController
 {
@@ -72,6 +73,7 @@ class Forum extends PageTypeController
 
         array_unshift($messages, $topic);
         $this->set('messages', $messages);
+        $this->set('user', new User());
 
         $this->render('topic', 'ortic_forum');
     }
@@ -97,6 +99,11 @@ class Forum extends PageTypeController
     {
         $forum = Core::make('ortic/forum');
         $message = $forum->getMessage($messageId);
+        $user = new User();
+        if($user->getUserId() != $message->user->getUserId()){
+            $this->showTopic($slug);
+            return;
+        }
         $forum->editMessage($message, $this->post('message'));
 
         $this->showTopic($slug);

--- a/controllers/page_types/Forum.php
+++ b/controllers/page_types/Forum.php
@@ -41,6 +41,9 @@ class Forum extends PageTypeController
             case '_answer':
                 $method = 'writeAnswer';
                 break;
+            case '_edit':
+                $method = 'updateMessage';
+                break;
             case '':
                 $method = 'showForum';
                 break;
@@ -83,6 +86,18 @@ class Forum extends PageTypeController
 
         $forum = Core::make('ortic/forum');
         $forum->writeAnswer($topic, $this->post('message'));
+
+        $this->showTopic($slug);
+    }
+
+    /**
+     * Adds a message to an existing topic
+     */
+    protected function updateMessage(string $slug, int $messageId)
+    {
+        $forum = Core::make('ortic/forum');
+        $message = $forum->getMessage($messageId);
+        $forum->writeAnswer($message, $this->post('message'));
 
         $this->showTopic($slug);
     }

--- a/controllers/page_types/Forum.php
+++ b/controllers/page_types/Forum.php
@@ -32,25 +32,23 @@ class Forum extends PageTypeController
         $this->parameter = join('/', $parameters);
         $this->lastParameter = end($parameters);
 
-        $method = null;
-
-        switch ($this->lastParameter) {
-            case '_new':
-                $method = 'writeTopic';
-                break;
-            case '_answer':
-                $method = 'writeAnswer';
-                break;
-            case '_edit':
-                $method = 'updateMessage';
-                break;
-            case '':
-                $method = 'showForum';
-                break;
-            default:
-                $method = 'showTopic';
-                break;
+        $method = 'showTopic'; //default
+        if($this->lastParameter == ''){
+            $method = 'showForum'; //show the forum if we have no params
+        } else if($this->getRequest()->isPost()) { //only call these if posted
+            switch ($this->lastParameter) {
+                case '_new':
+                    $method = 'writeTopic';
+                    break;
+                case '_answer':
+                    $method = 'writeAnswer';
+                    break;
+                case '_edit':
+                    $method = 'updateMessage';
+                    break;
+            }
         }
+        
         //call the appropriate method, passing parameters as parameters to the function
         call_user_func_array([$this, $method], $parameters);
 
@@ -71,6 +69,8 @@ class Forum extends PageTypeController
         $messages = $forum->getMessages($topic);
 
         $this->set('topic', $topic);
+
+        array_unshift($messages, $topic);
         $this->set('messages', $messages);
 
         $this->render('topic', 'ortic_forum');
@@ -97,7 +97,7 @@ class Forum extends PageTypeController
     {
         $forum = Core::make('ortic/forum');
         $message = $forum->getMessage($messageId);
-        $forum->writeAnswer($message, $this->post('message'));
+        $forum->editMessage($message, $this->post('message'));
 
         $this->showTopic($slug);
     }

--- a/controllers/page_types/Forum.php
+++ b/controllers/page_types/Forum.php
@@ -39,7 +39,6 @@ class Forum extends PageTypeController
                 $method = 'writeTopic';
                 break;
             case '_answer':
-                $this->writeAnswer();
                 $method = 'writeAnswer';
                 break;
             case '':

--- a/controllers/page_types/Forum.php
+++ b/controllers/page_types/Forum.php
@@ -32,29 +32,35 @@ class Forum extends PageTypeController
         $this->parameter = join('/', $parameters);
         $this->lastParameter = end($parameters);
 
+        $method = null;
+
         switch ($this->lastParameter) {
             case '_new':
-                $this->writeTopic();
+                $method = 'writeTopic';
                 break;
             case '_answer':
                 $this->writeAnswer();
+                $method = 'writeAnswer';
                 break;
             case '':
-                $this->showForum();
+                $method = 'showForum';
                 break;
             default:
-                $this->showTopic();
+                $method = 'showTopic';
                 break;
         }
+        //call the appropriate method, passing parameters as parameters to the function
+        call_user_func_array([$this, $method], $parameters);
+
     }
 
     /**
      * Displays all messages from a single topic
      */
-    protected function showTopic()
+    protected function showTopic(string $slug)
     {
         $forum = Core::make('ortic/forum');
-        $topic = $forum->getTopic($this->parameters[0]);
+        $topic = $forum->getTopic($slug);
 
         if (!$topic) {
             $this->replace('/page_not_found');
@@ -71,15 +77,15 @@ class Forum extends PageTypeController
     /**
      * Adds a message to an existing topic
      */
-    protected function writeAnswer()
+    protected function writeAnswer(string $slug)
     {
         $forum = Core::make('ortic/forum');
-        $topic = $forum->getTopic($this->parameters[0]);
+        $topic = $forum->getTopic($slug);
 
         $forum = Core::make('ortic/forum');
         $forum->writeAnswer($topic, $this->post('message'));
 
-        $this->showTopic();
+        $this->showTopic($slug);
     }
 
     /**

--- a/single_pages/forum.php
+++ b/single_pages/forum.php
@@ -5,6 +5,7 @@ $date = Core::make('date');
 <table class="table">
     <thead>
     <tr>
+        <th></th>
         <th><?= t('Subject') ?></th>
         <th><?= t('Author') ?></th>
         <th><?= t('Date') ?></th>
@@ -15,6 +16,9 @@ $date = Core::make('date');
     <?php foreach ($topics as $topic) {
         ?>
         <tr>
+            <td>
+            <?php View::element('user_avatar', ['user' => $topic->user], 'ortic_forum') ?>
+            </td>
             <td>
                 <a href="<?= $this->action($topic->getSlug()) ?>">
                     <?= $topic->getSubject() ?>

--- a/single_pages/topic.php
+++ b/single_pages/topic.php
@@ -12,7 +12,9 @@ function editClicked(event){
     }
 }
 </script>
-<?php foreach ($messages as $message) { ?>
+<?php foreach ($messages as $message) { 
+    $userIsOwner = ($user->getUserId() == $message->user->getUserId());
+    ?>
     <div class="ortic-forum-message row thumbnail">
         
         <div class="col-xs-1">
@@ -22,7 +24,7 @@ function editClicked(event){
             <div>
                 <strong><?php View::element('user_link', ['user' => $message->user], 'ortic_forum') ?></strong>
                 <?=Core::make('helper/date')->formatDateTime($topic->getDateCreated())?>
-                | <a onclick="editClicked(event)"><?= t('Edit') ?></a>
+                | <?php if($userIsOwner) {?><a onclick="editClicked(event)"><?= t('Edit') ?></a><?php }?>
             </div>
             <div class="ortic-forum-message-text">
                 <p>
@@ -37,8 +39,6 @@ function editClicked(event){
             </div>
 
         </div>
-        
-        
     </div>
 <?php } ?>
 

--- a/single_pages/topic.php
+++ b/single_pages/topic.php
@@ -1,22 +1,20 @@
 <h1><?= $topic->getSubject() ?></h1>
+<script type="text/javascript">
+function editClicked(event){
+    var parent = $(event.target).parent().parent();
+    parent.find('.ortic-forum-message-edit').toggle();
 
-<div class="ortic-forum-message row">
-    <div class="col-xs-1">
-        <?php View::element('user_avatar', ['user' => $topic->user], 'ortic_forum') ?>
-    </div>
-    <div class="col-xs-11">
-        <div>
-            <strong><?php View::element('user_link', ['user' => $topic->user], 'ortic_forum') ?></strong>
-            <?=Core::make('helper/date')->formatDateTime($topic->getDateCreated())?>
-        </div>
-        <p>
-            <?= nl2br($topic->getMessage()) ?>
-        </p>
-    </div>
-</div>
-
+    parent.find('.ortic-forum-message-text').toggle();
+    if($(event.target).html()=='<?= t('Edit') ?>') {
+        $(event.target).html('<?= t('Cancel Edit') ?>');
+    } else {
+        $(event.target).html('<?= t('Edit') ?>');
+    }
+}
+</script>
 <?php foreach ($messages as $message) { ?>
-    <div class="ortic-forum-message row">
+    <div class="ortic-forum-message row thumbnail">
+        
         <div class="col-xs-1">
             <?php View::element('user_avatar', ['user' => $message->user], 'ortic_forum') ?>
         </div>
@@ -24,11 +22,23 @@
             <div>
                 <strong><?php View::element('user_link', ['user' => $message->user], 'ortic_forum') ?></strong>
                 <?=Core::make('helper/date')->formatDateTime($topic->getDateCreated())?>
+                | <a onclick="editClicked(event)"><?= t('Edit') ?></a>
             </div>
-            <p>
-                <?= nl2br($message->getMessage()) ?>
-            </p>
+            <div class="ortic-forum-message-text">
+                <p>
+                    <?= nl2br($message->getMessage()) ?>
+                </p>
+            </div>
+            <div class="ortic-forum-message-edit" style="display:none;">
+                <form method="POST" action="<?= $this->action($topic->getSlug() . '/' . $message->getID() . '/_edit') ?>">
+                    <textarea type="text" class="form-control" name="message" id="message" placeholder=""><?= $message->getMessage() ?></textarea>
+                    <button class="btn btn-primary"><?= t('Save') ?></button>
+                </form>
+            </div>
+
         </div>
+        
+        
     </div>
 <?php } ?>
 

--- a/src/Repository/Forum.php
+++ b/src/Repository/Forum.php
@@ -26,6 +26,20 @@ class Forum
     }
 
     /**
+     * Returns a message by id
+     *
+     * @param string $slug
+     * @return mixed
+     */
+    public function getMessage(int $id)
+    {
+        $pkg = Package::getByHandle('ortic_forum');
+        $em = $pkg->getEntityManager();
+        $message = $em->getRepository('Concrete\Package\OrticForum\Src\Entity\ForumMessage')->find($id);
+        return $message;
+    }
+
+    /**
      * Returns a list of messages that belong to the topic specified by $topic
      *
      * @param ForumMessage $topic
@@ -93,6 +107,29 @@ class Forum
         $object->setPageId($page->getCollectionId());
 
         $em->persist($object);
+        $em->flush();
+    }
+
+    /**
+     * Adds a new topic to the current forum (page)
+     *
+     * @param string $subject
+     * @param string $message
+     */
+    public function editMessage(ForumMessage $message, string $subject, string $messageTxt)
+    {
+        $pkg = Package::getByHandle('ortic_forum');
+
+        $em = $pkg->getEntityManager();
+
+        $user = new User();
+        $page = Page::getCurrentPage();
+
+        $message->setSubject($subject);
+        $message->setMessage($messageTxt);
+        $message->setDateUpdated(new \DateTime);
+
+        $em->persist($message);
         $em->flush();
     }
 

--- a/src/Repository/Forum.php
+++ b/src/Repository/Forum.php
@@ -111,7 +111,7 @@ class Forum
     }
 
     /**
-     * Adds a new topic to the current forum (page)
+     * Modifies an existing message
      *
      * @param string $subject
      * @param string $message

--- a/src/Repository/Forum.php
+++ b/src/Repository/Forum.php
@@ -116,7 +116,7 @@ class Forum
      * @param string $subject
      * @param string $message
      */
-    public function editMessage(ForumMessage $message, string $subject, string $messageTxt)
+    public function editMessage(ForumMessage $message, string $messageTxt)
     {
         $pkg = Package::getByHandle('ortic_forum');
 
@@ -125,7 +125,6 @@ class Forum
         $user = new User();
         $page = Page::getCurrentPage();
 
-        $message->setSubject($subject);
         $message->setMessage($messageTxt);
         $message->setDateUpdated(new \DateTime);
 


### PR DESCRIPTION
In this PR I added the ability to edit messages, and refactored the routing in the controller a little bit so the action methods can just take parameters and don't need to rely on `$this->pageParameters` anymore. This also kinda adds some validation via type hints.

I also added the user's avatar to the topic list.

~~Right now anyone can edit messages though, so I need to lock that down next.~~ Done