### PR TITLE
Fixed (removed) type hints for compatibility with older PHP versions

### DIFF
--- a/controllers/page_types/ForumTopic.php
+++ b/controllers/page_types/ForumTopic.php
@@ -108,7 +108,7 @@ class ForumTopic extends PageTypeController
      * @param int $messageId
      * @return \Concrete\Core\Routing\RedirectResponse|void
      */
-    public function updateMessage(int $messageId)
+    public function updateMessage($messageId)
     {
         $token = Core::make('token');
 
@@ -144,7 +144,7 @@ class ForumTopic extends PageTypeController
      * @param string $tokenId
      * @return \Concrete\Core\Routing\RedirectResponse|void
      */
-    public function deleteMessage(int $messageId, $tokenId)
+    public function deleteMessage($messageId, $tokenId)
     {
         $token = Core::make('token');
 

--- a/src/Repository/Forum.php
+++ b/src/Repository/Forum.php
@@ -27,7 +27,7 @@ class Forum
      * @param int $id
      * @return mixed
      */
-    public function getTopicById(int $id)
+    public function getTopicById($id)
     {
         $pkg = Core::make(PackageService::class)->getByHandle('ortic_forum');
         $em = $pkg->getEntityManager();
@@ -41,7 +41,7 @@ class Forum
      * @param int $id
      * @return mixed
      */
-    public function getMessage(int $id)
+    public function getMessage($id)
     {
         $pkg = Core::make(PackageService::class)->getByHandle('ortic_forum');
         $em = $pkg->getEntityManager();
@@ -90,7 +90,7 @@ class Forum
      * @return ForumMessage
      * @throws \Exception
      */
-    public function writeAnswer(string $message, Version $attachment = null)
+    public function writeAnswer($message, Version $attachment = null)
     {
         $pkg = Core::make(PackageService::class)->getByHandle('ortic_forum');
         $em = $pkg->getEntityManager();
@@ -170,7 +170,7 @@ class Forum
      * @param ForumMessage $message
      * @param string $messageTxt
      */
-    public function updateMessage(ForumMessage $message, string $messageTxt)
+    public function updateMessage(ForumMessage $message, $messageTxt)
     {
         $pkg = Core::make(PackageService::class)->getByHandle('ortic_forum');
 
@@ -263,7 +263,7 @@ class Forum
      * @param Version $attachment
      * @return \Concrete\Core\Page\Page
      */
-    public function writeTopic(string $subject, string $message, Version $attachment = null)
+    public function writeTopic($subject, $message, Version $attachment = null)
     {
         $pkg = Core::make(PackageService::class)->getByHandle('ortic_forum');
 


### PR DESCRIPTION
# Description

PHP versions older than 7 only support type hints for objects and arrays, so having type hints for ints and strings is breaking on PHP 5.6.

This PR fixes that by removing type hints for `int`s and `string`s.
